### PR TITLE
高速に拡大縮小等を繰り返すと落ちることがある問題を修正。（

### DIFF
--- a/TaskManagement/UI/WorkItemGrid.cs
+++ b/TaskManagement/UI/WorkItemGrid.cs
@@ -54,6 +54,7 @@ namespace TaskManagement.UI
             ApplyDetailSetting(_viewData.Detail);
             _editService = new WorkItemEditService(_viewData, _undoService);
             LockUpdate = false;
+            if (_drawService != null) _drawService.Dispose();
             _drawService = new DrawService(
                 _viewData,
                 this,


### PR DESCRIPTION
_drawService及び、その内部のインスタンスがDisposeされずに次のインスタンスが生成されてメモリ不足になっていたことが原因と思われる。）